### PR TITLE
gitsecure auto-remediation

### DIFF
--- a/kcontainer/fleet-quarkus-ms/src/main/docker/Dockerfile.jvm
+++ b/kcontainer/fleet-quarkus-ms/src/main/docker/Dockerfile.jvm
@@ -22,7 +22,9 @@ ENV AB_ENABLED=jmx_exporter
 RUN adduser -G root --no-create-home --disabled-password 1001 \
   && chown -R 1001 /deployments \
   && chmod -R "g+rwX" /deployments \
-  && chown -R 1001:root /deployments
+#GITSECURE REMEDIATION 
+RUN  apk update && apk add  
+
 
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar

--- a/kcontainer/order-command-quarkus-ms/src/main/docker/Dockerfile.jvm
+++ b/kcontainer/order-command-quarkus-ms/src/main/docker/Dockerfile.jvm
@@ -22,7 +22,9 @@ ENV AB_ENABLED=jmx_exporter
 RUN adduser -G root --no-create-home --disabled-password 1001 \
   && chown -R 1001 /deployments \
   && chmod -R "g+rwX" /deployments \
-  && chown -R 1001:root /deployments
+#GITSECURE REMEDIATION 
+RUN  apk update && apk add  
+
 
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar

--- a/kcontainer/order-command-quarkus-ms/src/main/docker/Dockerfile.jvm-back
+++ b/kcontainer/order-command-quarkus-ms/src/main/docker/Dockerfile.jvm-back
@@ -20,6 +20,7 @@ LABEL maintainer="IBM Cloud Architecture Solution Engineering at IBM Cloud"
 
 RUN apt-get update && \
  apt-get install -y maven
+   
 
  # attach volumes
 VOLUME /volume/gitrepo
@@ -30,7 +31,6 @@ WORKDIR /local/gitrepo
 COPY src/ /local/gitrepo/src
 COPY pom.xml /local/gitrepo/pom.xml
 
-RUN mvn package -DskipTests=true
 
 ### Stage 2 - Docker Build
 FROM fabric8/java-alpine-openjdk8-jre:1.6.5
@@ -41,7 +41,9 @@ ENV AB_ENABLED=jmx_exporter
 RUN adduser -G root --no-create-home --disabled-password 1001 \
   && chown -R 1001 /deployments \
   && chmod -R "g+rwX" /deployments \
-  && chown -R 1001:root /deployments
+#GITSECURE REMEDIATION 
+RUN  apt-get update && apt-get install -y --fix-missing  
+
 
 #COPY target/lib/* /deployments/lib/
 #COPY target/*-runner.jar /deployments/app.jar

--- a/kcontainer/order-query-quarkus-ms/src/main/docker/Dockerfile.jvm
+++ b/kcontainer/order-query-quarkus-ms/src/main/docker/Dockerfile.jvm
@@ -22,7 +22,9 @@ ENV AB_ENABLED=jmx_exporter
 RUN adduser -G root --no-create-home --disabled-password 1001 \
   && chown -R 1001 /deployments \
   && chmod -R "g+rwX" /deployments \
-  && chown -R 1001:root /deployments
+#GITSECURE REMEDIATION 
+RUN  apk update && apk add  
+
 
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar

--- a/kcontainer/refarch-kc-ui/Dockerfile
+++ b/kcontainer/refarch-kc-ui/Dockerfile
@@ -9,9 +9,13 @@ RUN   cd ui \
       && ng build \
       && cd ../server \
       && npm install \
-      && npm run build
+#GITSECURE REMEDIATION 
+RUN  apk update && apk add  
 
-FROM node:alpine
+
+#GITSECURE REMEDIATION 
+RUN  apt-get update && apt-get install -y --fix-missing  
+
 MAINTAINER https://github.com/ibm-cloud-architecture - IBM - Jerome Boyer
 
 WORKDIR /kc-ui/server

--- a/kcontainer/spring-container-ms/Dockerfile
+++ b/kcontainer/spring-container-ms/Dockerfile
@@ -25,7 +25,11 @@ RUN bash -c " export POSTGRESQL_URL=${POSTGRESQL_URL} \
 	&& export JKS_LOCATION=\"/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts\" \
 	&& export TRUSTSTORE_PWD=${TRUSTSTORE_PWD} \
 	&& ./scripts/add_certificates.sh \
-	&& mvn clean install -DskipTests -Djavax.net.ssl.trustStore=${JAVA_HOME}/jre/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=$TRUSTSTORE_PWD -Duser.home=/var/maven"
+#GITSECURE REMEDIATION 
+RUN  apt-get update && apt-get install -y --fix-missing git=1:2.11.0-3+deb9u5  subversion=1.9.5-1+deb9u4 \ 
+     wget=1.18-5+deb9u3  openssl=1.1.0l-1~deb9u1 \ 
+     e2fsprogs=1.43.4-2+deb9u1   
+
 
 # Deploy stage
 # Use jre small foot print image. See https://hub.docker.com/_/ibmjava/
@@ -35,10 +39,7 @@ COPY --from=builder /usr/src/app/target/SpringContainerMS-1.0-SNAPSHOT.jar $APP_
 LABEL maintainer="IBM Java Engineering at IBM Cloud"
 
 # Install Extra Packages
-RUN apt-get update \
- && apt-get install -y jq bash bc ca-certificates curl nodejs \
- && update-ca-certificates \
- && mkdir -p $APP_HOME/scripts
+RUN apt1.0.9.8.5 update \ && apt-get install -y jq bash4.3-11+deb8u2 bc ca-certificates curl7.52.1-5+deb9u10 nodejs \ && update-ca-certificates \ && mkdir -p $APP_HOME/scripts   git1:2.11.0-3+deb9u5  dbus1.8.22-0+deb8u2  subversion1.9.5-1+deb9u4  wget1.18-5+deb9u3  openssl1.1.0l-1~deb9u1  systemd215-17+deb8u12  mercurial3.1.2-2+deb8u7  sensible-utils0.0.9+deb8u1  perl5.20.2-3+deb8u12  procps2:3.3.9-9+deb8u1  bzip21.0.6-7+deb8u1  libxml22.9.1+dfsg1-5+deb8u8  tar1.27.1-2+deb8u2  e2fsprogs1.43.4-2+deb9u1  bzr2.6.0+bzr6595-6+deb8u1  python2.72.7.9-2+deb8u5  unzip6.0-21+deb9u1  gnupg1.4.18-7+deb8u4  
 
 WORKDIR $APP_HOME
 

--- a/kcontainer/utils/cli/Dockerfile
+++ b/kcontainer/utils/cli/Dockerfile
@@ -2,7 +2,9 @@ FROM node:12
 
 WORKDIR "/tools"
 ADD . /tools
-RUN  npm install
+#GITSECURE REMEDIATION 
+RUN  apt-get update && apt-get install -y --fix-missing  
+
 ENV PATH="/tools:${PATH}"
 
 ENTRYPOINT ["bash"]

--- a/kcontainer/voyages-ms/Dockerfile
+++ b/kcontainer/voyages-ms/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update \
  && export LDFLAGS=-L/usr/local/opt/openssl/lib \
  && export CPPFLAGS=-I/usr/local/opt/openssl/include \
  && echo 'Finished installing dependencies'
+   
 
 # Install npm production packages
 COPY package.json /app/
-RUN cd /app && npm install --production
 
 COPY . /app
 


### PR DESCRIPTION
# GitSecure Vulnerablility Report

| Control ID | Section | Description |
|------------|---------|-------------|
| RA-5 | Risk Assessment | Vulnerability Scanning |
| CA-7 | Security Assessment and Authorization | Continuous Monitoring |
| SA-12 | System and Services Acquisition | Supply Chain Protection |
| SI-2 | System and Information Integrity | Flaw Remediation |
| CM-4 | Configuration Management | Security Impact Analysis |
| CA-2 | Security Assessment and Authorization | Security Assessments |

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/voyages-ms/Dockerfile
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:x: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>
Package Name: <strong> kind-of </strong> Version : <strong> 6.0.2 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: CVE-2019-20149
	 Severity:  MODERATE
	 Fixed in Version:  6.0.3
	 Description:  ctorName in index.js in kind-of v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by 'constructor': {'name':'Symbol'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.

	 CVE ID: GHSA-6c8f-qphg-qjgp
	 Severity:  MODERATE
	 Fixed in Version:  6.0.3
	 Description:  ctorName in index.js in kind-of v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by 'constructor': {'name':'Symbol'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.

</details>
</p>

Package Name: <strong> minimist </strong> Version : <strong> 0.0.8 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: GHSA-7fhm-mqm4-2wp7
	 Severity:  MODERATE
	 Fixed in Version:  0.2.1
	 Description:  **Withdrawn**
GitHub has withdrawn this advisory in place of GHSA-vh95-rmgr-6w4m and GHSA-6chw-6frg-f759.
The reason for withdrawing is that some mistakes were made during the ingestion of CVE-2020-7598
which caused this advisory to be published with incorrect information.

In order to provide accurate advisory information, new advisories were created:

- minimist: https://github.com/advisories/GHSA-vh95-rmgr-6w4m
- acorn: https://github.com/advisories/GHSA-6chw-6frg-f759

</details>
</p>


</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/utils/cli/Dockerfile
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/spring-container-ms/Dockerfile
  </summary> 

:x: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:x: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>
<p>
<details>
<summary> Package Name: git | Current Version: 1:2.11.0-3+deb9u4   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1:2.11.0-3+deb9u5 
1. [CVE-2019-1352](https://security-tracker.debian.org/tracker/CVE-2019-1352 "CVE-2019-1352")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

2. [CVE-2019-1387](https://security-tracker.debian.org/tracker/CVE-2019-1387 "CVE-2019-1387")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

3. [CVE-2019-1349](https://security-tracker.debian.org/tracker/CVE-2019-1349 "CVE-2019-1349")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

4. [CVE-2019-1353](https://security-tracker.debian.org/tracker/CVE-2019-1353 "CVE-2019-1353")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

5. [CVE-2019-1348](https://security-tracker.debian.org/tracker/CVE-2019-1348 "CVE-2019-1348")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

</details>
</p>

<p>
<details>
<summary> Package Name: subversion | Current Version: 1.9.5-1+deb9u3   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.9.5-1+deb9u4 
1. [CVE-2018-11782](https://security-tracker.debian.org/tracker/CVE-2018-11782 "CVE-2018-11782")   
Severity: Unknown   
Fixed in: 1.9.5-1+deb9u4   

2. [CVE-2019-0203](https://security-tracker.debian.org/tracker/CVE-2019-0203 "CVE-2019-0203")   
Severity: Unknown   
Fixed in: 1.9.5-1+deb9u4   

</details>
</p>

<p>
<details>
<summary> Package Name: wget | Current Version: 1.18-5+deb9u2   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.18-5+deb9u3 
1. [CVE-2019-5953](https://security-tracker.debian.org/tracker/CVE-2019-5953 "CVE-2019-5953")   
Severity: Unknown   
Fixed in: 1.18-5+deb9u3   

</details>
</p>

<p>
<details>
<summary> Package Name: openssl | Current Version: 1.1.0j-1~deb9u1   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.1.0l-1~deb9u1 
1. [CVE-2019-1543](https://security-tracker.debian.org/tracker/CVE-2019-1543 "CVE-2019-1543")   
Severity: Low   
Fixed in: 1.1.0k-1~deb9u1   

2. [CVE-2019-1547](https://security-tracker.debian.org/tracker/CVE-2019-1547 "CVE-2019-1547")   
Severity: Unknown   
Fixed in: 1.1.0l-1~deb9u1   

3. [CVE-2019-1563](https://security-tracker.debian.org/tracker/CVE-2019-1563 "CVE-2019-1563")   
Severity: Unknown   
Fixed in: 1.1.0l-1~deb9u1   

</details>
</p>

<p>
<details>
<summary> Package Name: e2fsprogs | Current Version: 1.43.4-2   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.43.4-2+deb9u1 
1. [CVE-2019-5094](https://security-tracker.debian.org/tracker/CVE-2019-5094 "CVE-2019-5094")   
Severity: Unknown   
Fixed in: 1.43.4-2+deb9u1   

</details>
</p>


</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>
Package Name: <strong> org.apache.zookeeper:zookeeper </strong> Version : <strong> 3.4.13 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: CVE-2019-0201
	 Severity:  MODERATE
	 Fixed in Version:  3.4.14
	 Description:  An issue is present in Apache ZooKeeper 1.0.0 to 3.4.13 and 3.5.0-alpha to 3.5.4-beta. ZooKeeper?s getACL() command doesn?t check any permission when retrieves the ACLs of the requested node and returns all information contained in the ACL Id field as plaintext string. DigestAuthenticationProvider overloads the Id field with the hash value that is used for user authentication. As a consequence, if Digest Authentication is in use, the unsalted hash value will be disclosed by getACL() request for unauthenticated or unprivileged users.

	 CVE ID: GHSA-2hw2-62cp-p9p7
	 Severity:  MODERATE
	 Fixed in Version:  3.4.14
	 Description:  An issue is present in Apache ZooKeeper 1.0.0 to 3.4.13 and 3.5.0-alpha to 3.5.4-beta. ZooKeeper?s getACL() command doesn?t check any permission when retrieves the ACLs of the requested node and returns all information contained in the ACL Id field as plaintext string. DigestAuthenticationProvider overloads the Id field with the hash value that is used for user authentication. As a consequence, if Digest Authentication is in use, the unsalted hash value will be disclosed by getACL() request for unauthenticated or unprivileged users.

</details>
</p>

Package Name: <strong> org.apache.tomcat.embed:tomcat-embed-core </strong> Version : <strong> 9.0.17 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: CVE-2019-17563
	 Severity:  HIGH
	 Fixed in Version:  9.0.30
	 Description:  When using FORM authentication with Apache Tomcat 9.0.0.M1 to 9.0.29, 8.5.0 to 8.5.49 and 7.0.0 to 7.0.98 there was a narrow window where an attacker could perform a session fixation attack. The window was considered too narrow for an exploit to be practical but, erring on the side of caution, this issue has been treated as a security vulnerability.

	 CVE ID: GHSA-9xcj-c8cr-8c3c
	 Severity:  HIGH
	 Fixed in Version:  9.0.30
	 Description:  When using FORM authentication with Apache Tomcat 9.0.0.M1 to 9.0.29, 8.5.0 to 8.5.49 and 7.0.0 to 7.0.98 there was a narrow window where an attacker could perform a session fixation attack. The window was considered too narrow for an exploit to be practical but, erring on the side of caution, this issue has been treated as a security vulnerability.

	 CVE ID: CVE-2019-12418
	 Severity:  MODERATE
	 Fixed in Version:  9.0.29
	 Description:  When Apache Tomcat 9.0.0.M1 to 9.0.28, 8.5.0 to 8.5.47, 7.0.0 and 7.0.97 is configured with the JMX Remote Lifecycle Listener, a local attacker without access to the Tomcat process or configuration files is able to manipulate the RMI registry to perform a man-in-the-middle attack to capture user names and passwords used to access the JMX interface. The attacker can then use these credentials to access the JMX interface and gain complete control over the Tomcat instance.

	 CVE ID: GHSA-hh3j-x4mc-g48r
	 Severity:  MODERATE
	 Fixed in Version:  9.0.29
	 Description:  When Apache Tomcat 9.0.0.M1 to 9.0.28, 8.5.0 to 8.5.47, 7.0.0 and 7.0.97 is configured with the JMX Remote Lifecycle Listener, a local attacker without access to the Tomcat process or configuration files is able to manipulate the RMI registry to perform a man-in-the-middle attack to capture user names and passwords used to access the JMX interface. The attacker can then use these credentials to access the JMX interface and gain complete control over the Tomcat instance.

	 CVE ID: CVE-2020-1935
	 Severity:  MODERATE
	 Fixed in Version:  9.0.31
	 Description:  In Apache Tomcat 9.0.0.M1 to 9.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99 the HTTP header parsing code used an approach to end-of-line parsing that allowed some invalid HTTP headers to be parsed as valid. This led to a possibility of HTTP Request Smuggling if Tomcat was located behind a reverse proxy that incorrectly handled the invalid Transfer-Encoding header in a particular manner. Such a reverse proxy is considered unlikely.

	 CVE ID: GHSA-qxf4-chvg-4r8r
	 Severity:  MODERATE
	 Fixed in Version:  9.0.31
	 Description:  In Apache Tomcat 9.0.0.M1 to 9.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99 the HTTP header parsing code used an approach to end-of-line parsing that allowed some invalid HTTP headers to be parsed as valid. This led to a possibility of HTTP Request Smuggling if Tomcat was located behind a reverse proxy that incorrectly handled the invalid Transfer-Encoding header in a particular manner. Such a reverse proxy is considered unlikely.

</details>
</p>


</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/spring-container-ms/Dockerfile
  </summary> 

:x: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:x: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>
<p>
<details>
<summary> Package Name: git | Current Version: 1:2.1.4-2.1+deb8u2   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1:2.11.0-3+deb9u5 
1. [CVE-2019-1352](https://security-tracker.debian.org/tracker/CVE-2019-1352 "CVE-2019-1352")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

2. [CVE-2019-1348](https://security-tracker.debian.org/tracker/CVE-2019-1348 "CVE-2019-1348")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

3. [CVE-2019-1353](https://security-tracker.debian.org/tracker/CVE-2019-1353 "CVE-2019-1353")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

4. [CVE-2019-1387](https://security-tracker.debian.org/tracker/CVE-2019-1387 "CVE-2019-1387")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

5. [CVE-2019-1349](https://security-tracker.debian.org/tracker/CVE-2019-1349 "CVE-2019-1349")   
Severity: Unknown   
Fixed in: 1:2.11.0-3+deb9u5   

6. [CVE-2018-11233](https://security-tracker.debian.org/tracker/CVE-2018-11233 "CVE-2018-11233")   
Severity: Negligible   
Fixed in: 1:2.1.4-2.1+deb8u6   

7. [CVE-2017-8386](https://security-tracker.debian.org/tracker/CVE-2017-8386 "CVE-2017-8386")   
Severity: Unknown   
Fixed in: 1:2.1.4-2.1+deb8u3   

8. [CVE-2017-14867](https://security-tracker.debian.org/tracker/CVE-2017-14867 "CVE-2017-14867")   
Severity: Unknown   
Fixed in: 1:2.1.4-2.1+deb8u5   

</details>
</p>

<p>
<details>
<summary> Package Name: dbus | Current Version: 1.8.22-0+deb8u1   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.8.22-0+deb8u2 
1. [CVE-2019-12749](https://security-tracker.debian.org/tracker/CVE-2019-12749 "CVE-2019-12749")   
Severity: Unknown   
Fixed in: 1.8.22-0+deb8u2   

</details>
</p>

<p>
<details>
<summary> Package Name: apt | Current Version: 1.0.9.8.4   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.0.9.8.5 
1. [CVE-2019-3462](https://security-tracker.debian.org/tracker/CVE-2019-3462 "CVE-2019-3462")   
Severity: Unknown   
Fixed in: 1.0.9.8.5   

</details>
</p>

<p>
<details>
<summary> Package Name: subversion | Current Version: 1.8.10-6+deb8u4   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.9.5-1+deb9u4 
1. [CVE-2016-8734](https://security-tracker.debian.org/tracker/CVE-2016-8734 "CVE-2016-8734")   
Severity: Low   
Fixed in: 1.8.10-6+deb8u5   

2. [CVE-2019-0203](https://security-tracker.debian.org/tracker/CVE-2019-0203 "CVE-2019-0203")   
Severity: Unknown   
Fixed in: 1.9.5-1+deb9u4   

3. [CVE-2017-9800](https://security-tracker.debian.org/tracker/CVE-2017-9800 "CVE-2017-9800")   
Severity: Unknown   
Fixed in: 1.8.10-6+deb8u5   

4. [CVE-2018-11782](https://security-tracker.debian.org/tracker/CVE-2018-11782 "CVE-2018-11782")   
Severity: Unknown   
Fixed in: 1.9.5-1+deb9u4   

</details>
</p>

<p>
<details>
<summary> Package Name: wget | Current Version: 1.16-1+deb8u1   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.18-5+deb9u3 
1. [CVE-2016-7098](https://security-tracker.debian.org/tracker/CVE-2016-7098 "CVE-2016-7098")   
Severity: Low   
Fixed in: 1.16-1+deb8u7   

2. [CVE-2017-6508](https://security-tracker.debian.org/tracker/CVE-2017-6508 "CVE-2017-6508")   
Severity: Unknown   
Fixed in: 1.16-1+deb8u2   

3. [CVE-2017-13090](https://security-tracker.debian.org/tracker/CVE-2017-13090 "CVE-2017-13090")   
Severity: Unknown   
Fixed in: 1.16-1+deb8u4   

4. [CVE-2019-5953](https://security-tracker.debian.org/tracker/CVE-2019-5953 "CVE-2019-5953")   
Severity: Unknown   
Fixed in: 1.18-5+deb9u3   

5. [CVE-2017-13089](https://security-tracker.debian.org/tracker/CVE-2017-13089 "CVE-2017-13089")   
Severity: Unknown   
Fixed in: 1.16-1+deb8u4   

6. [CVE-2018-0494](https://security-tracker.debian.org/tracker/CVE-2018-0494 "CVE-2018-0494")   
Severity: Unknown   
Fixed in: 1.16-1+deb8u5   

</details>
</p>

<p>
<details>
<summary> Package Name: openssl | Current Version: 1.0.1t-1+deb8u6   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.1.0l-1~deb9u1 
1. [CVE-2018-0739](https://security-tracker.debian.org/tracker/CVE-2018-0739 "CVE-2018-0739")   
Severity: Low   
Fixed in: 1.0.1t-1+deb8u8   

2. [CVE-2018-5407](https://security-tracker.debian.org/tracker/CVE-2018-5407 "CVE-2018-5407")   
Severity: Unknown   
Fixed in: 1.0.1t-1+deb8u10   

3. [CVE-2018-0737](https://security-tracker.debian.org/tracker/CVE-2018-0737 "CVE-2018-0737")   
Severity: Low   
Fixed in: 1.0.1t-1+deb8u9   

4. [CVE-2019-1563](https://security-tracker.debian.org/tracker/CVE-2019-1563 "CVE-2019-1563")   
Severity: Unknown   
Fixed in: 1.1.0l-1~deb9u1   

5. [CVE-2017-3735](https://security-tracker.debian.org/tracker/CVE-2017-3735 "CVE-2017-3735")   
Severity: Unknown   
Fixed in: 1.0.1t-1+deb8u7   

6. [CVE-2018-0735](https://security-tracker.debian.org/tracker/CVE-2018-0735 "CVE-2018-0735")   
Severity: Negligible   
Fixed in: 1.0.1t-1+deb8u10   

7. [CVE-2019-1547](https://security-tracker.debian.org/tracker/CVE-2019-1547 "CVE-2019-1547")   
Severity: Unknown   
Fixed in: 1.1.0l-1~deb9u1   

8. [CVE-2018-0732](https://security-tracker.debian.org/tracker/CVE-2018-0732 "CVE-2018-0732")   
Severity: Low   
Fixed in: 1.0.1t-1+deb8u9   

</details>
</p>

<p>
<details>
<summary> Package Name: systemd | Current Version: 215-17+deb8u6   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 215-17+deb8u12 
1. [CVE-2019-6454](https://security-tracker.debian.org/tracker/CVE-2019-6454 "CVE-2019-6454")   
Severity: Unknown   
Fixed in: 215-17+deb8u10   

2. [CVE-2019-3815](https://security-tracker.debian.org/tracker/CVE-2019-3815 "CVE-2019-3815")   
Severity: Negligible   
Fixed in: 215-17+deb8u11   

3. [CVE-2018-15688](https://security-tracker.debian.org/tracker/CVE-2018-15688 "CVE-2018-15688")   
Severity: Negligible   
Fixed in: 215-17+deb8u8   

4. [CVE-2017-18078](https://security-tracker.debian.org/tracker/CVE-2017-18078 "CVE-2017-18078")   
Severity: Negligible   
Fixed in: 215-17+deb8u12   

5. [CVE-2018-1049](https://security-tracker.debian.org/tracker/CVE-2018-1049 "CVE-2018-1049")   
Severity: Unknown   
Fixed in: 215-17+deb8u8   

6. [CVE-2018-16865](https://security-tracker.debian.org/tracker/CVE-2018-16865 "CVE-2018-16865")   
Severity: Unknown   
Fixed in: 215-17+deb8u9   

7. [CVE-2018-15686](https://security-tracker.debian.org/tracker/CVE-2018-15686 "CVE-2018-15686")   
Severity: Unknown   
Fixed in: 215-17+deb8u8   

8. [CVE-2018-16864](https://security-tracker.debian.org/tracker/CVE-2018-16864 "CVE-2018-16864")   
Severity: Unknown   
Fixed in: 215-17+deb8u9   

</details>
</p>

<p>
<details>
<summary> Package Name: mercurial | Current Version: 3.1.2-2+deb8u3   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 3.1.2-2+deb8u7 
1. [CVE-2018-13346](https://security-tracker.debian.org/tracker/CVE-2018-13346 "CVE-2018-13346")   
Severity: Unknown   
Fixed in: 3.1.2-2+deb8u5   

2. [CVE-2019-3902](https://security-tracker.debian.org/tracker/CVE-2019-3902 "CVE-2019-3902")   
Severity: Unknown   
Fixed in: 3.1.2-2+deb8u7   

3. [CVE-2017-1000116](https://security-tracker.debian.org/tracker/CVE-2017-1000116 "CVE-2017-1000116")   
Severity: Unknown   
Fixed in: 3.1.2-2+deb8u4   

4. [CVE-2017-1000115](https://security-tracker.debian.org/tracker/CVE-2017-1000115 "CVE-2017-1000115")   
Severity: Unknown   
Fixed in: 3.1.2-2+deb8u4   

5. [CVE-2018-13347](https://security-tracker.debian.org/tracker/CVE-2018-13347 "CVE-2018-13347")   
Severity: Unknown   
Fixed in: 3.1.2-2+deb8u5   

6. [CVE-2018-13348](https://security-tracker.debian.org/tracker/CVE-2018-13348 "CVE-2018-13348")   
Severity: Unknown   
Fixed in: 3.1.2-2+deb8u5   

7. [CVE-2018-1000132](https://security-tracker.debian.org/tracker/CVE-2018-1000132 "CVE-2018-1000132")   
Severity: Unknown   
Fixed in: 3.1.2-2+deb8u5   

8. [CVE-2017-17458](https://security-tracker.debian.org/tracker/CVE-2017-17458 "CVE-2017-17458")   
Severity: Unknown   
Fixed in: 3.1.2-2+deb8u6   

</details>
</p>

<p>
<details>
<summary> Package Name: sensible-utils | Current Version: 0.0.9   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 0.0.9+deb8u1 
1. [CVE-2017-17512](https://security-tracker.debian.org/tracker/CVE-2017-17512 "CVE-2017-17512")   
Severity: Unknown   
Fixed in: 0.0.9+deb8u1   

</details>
</p>

<p>
<details>
<summary> Package Name: perl | Current Version: 5.20.2-3+deb8u6   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 5.20.2-3+deb8u12 
1. [CVE-2018-12015](https://security-tracker.debian.org/tracker/CVE-2018-12015 "CVE-2018-12015")   
Severity: Unknown   
Fixed in: 5.20.2-3+deb8u11   

2. [CVE-2018-18311](https://security-tracker.debian.org/tracker/CVE-2018-18311 "CVE-2018-18311")   
Severity: Unknown   
Fixed in: 5.20.2-3+deb8u12   

3. [CVE-2017-6512](https://security-tracker.debian.org/tracker/CVE-2017-6512 "CVE-2017-6512")   
Severity: Unknown   
Fixed in: 5.20.2-3+deb8u7   

4. [CVE-2018-6913](https://security-tracker.debian.org/tracker/CVE-2018-6913 "CVE-2018-6913")   
Severity: Unknown   
Fixed in: 5.20.2-3+deb8u10   

</details>
</p>

<p>
<details>
<summary> Package Name: procps | Current Version: 2:3.3.9-9   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 2:3.3.9-9+deb8u1 
1. [CVE-2018-1125](https://security-tracker.debian.org/tracker/CVE-2018-1125 "CVE-2018-1125")   
Severity: Unknown   
Fixed in: 2:3.3.9-9+deb8u1   

2. [CVE-2018-1123](https://security-tracker.debian.org/tracker/CVE-2018-1123 "CVE-2018-1123")   
Severity: Unknown   
Fixed in: 2:3.3.9-9+deb8u1   

3. [CVE-2018-1124](https://security-tracker.debian.org/tracker/CVE-2018-1124 "CVE-2018-1124")   
Severity: Unknown   
Fixed in: 2:3.3.9-9+deb8u1   

4. [CVE-2018-1126](https://security-tracker.debian.org/tracker/CVE-2018-1126 "CVE-2018-1126")   
Severity: Unknown   
Fixed in: 2:3.3.9-9+deb8u1   

5. [CVE-2018-1122](https://security-tracker.debian.org/tracker/CVE-2018-1122 "CVE-2018-1122")   
Severity: Unknown   
Fixed in: 2:3.3.9-9+deb8u1   

</details>
</p>

<p>
<details>
<summary> Package Name: bzip2 | Current Version: 1.0.6-7+b3   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.0.6-7+deb8u1 
1. [CVE-2019-12900](https://security-tracker.debian.org/tracker/CVE-2019-12900 "CVE-2019-12900")   
Severity: Unknown   
Fixed in: 1.0.6-7+deb8u1   

2. [CVE-2016-3189](https://security-tracker.debian.org/tracker/CVE-2016-3189 "CVE-2016-3189")   
Severity: Low   
Fixed in: 1.0.6-7+deb8u1   

</details>
</p>

<p>
<details>
<summary> Package Name: libxml2 | Current Version: 2.9.1+dfsg1-5+deb8u4   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 2.9.1+dfsg1-5+deb8u8 
1. [CVE-2019-19956](https://security-tracker.debian.org/tracker/CVE-2019-19956 "CVE-2019-19956")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u8   

2. [CVE-2017-9050](https://security-tracker.debian.org/tracker/CVE-2017-9050 "CVE-2017-9050")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u5   

3. [CVE-2017-18258](https://security-tracker.debian.org/tracker/CVE-2017-18258 "CVE-2017-18258")   
Severity: Low   
Fixed in: 2.9.1+dfsg1-5+deb8u7   

4. [CVE-2017-9049](https://security-tracker.debian.org/tracker/CVE-2017-9049 "CVE-2017-9049")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u5   

5. [CVE-2017-9048](https://security-tracker.debian.org/tracker/CVE-2017-9048 "CVE-2017-9048")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u5   

6. [CVE-2018-14404](https://security-tracker.debian.org/tracker/CVE-2018-14404 "CVE-2018-14404")   
Severity: Low   
Fixed in: 2.9.1+dfsg1-5+deb8u7   

7. [CVE-2017-7376](https://security-tracker.debian.org/tracker/CVE-2017-7376 "CVE-2017-7376")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u5   

8. [CVE-2017-16931](https://security-tracker.debian.org/tracker/CVE-2017-16931 "CVE-2017-16931")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u5   

9. [CVE-2017-15412](https://security-tracker.debian.org/tracker/CVE-2017-15412 "CVE-2017-15412")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u6   

10. [CVE-2017-7375](https://security-tracker.debian.org/tracker/CVE-2017-7375 "CVE-2017-7375")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u5   

11. [CVE-2017-0663](https://security-tracker.debian.org/tracker/CVE-2017-0663 "CVE-2017-0663")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u5   

12. [CVE-2018-14567](https://security-tracker.debian.org/tracker/CVE-2018-14567 "CVE-2018-14567")   
Severity: Unknown   
Fixed in: 2.9.1+dfsg1-5+deb8u7   

</details>
</p>

<p>
<details>
<summary> Package Name: tar | Current Version: 1.27.1-2+deb8u1   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.27.1-2+deb8u2 
1. [CVE-2018-20482](https://security-tracker.debian.org/tracker/CVE-2018-20482 "CVE-2018-20482")   
Severity: Unknown   
Fixed in: 1.27.1-2+deb8u2   

</details>
</p>

<p>
<details>
<summary> Package Name: e2fsprogs | Current Version: 1.42.12-2+b1   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.43.4-2+deb9u1 
1. [CVE-2019-5188](https://security-tracker.debian.org/tracker/CVE-2019-5188 "CVE-2019-5188")   
Severity: Unknown   
Fixed in: 1.42.12-2+deb8u2   

2. [CVE-2019-5094](https://security-tracker.debian.org/tracker/CVE-2019-5094 "CVE-2019-5094")   
Severity: Unknown   
Fixed in: 1.43.4-2+deb9u1   

</details>
</p>

<p>
<details>
<summary> Package Name: bzr | Current Version: 2.6.0+bzr6595-6   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 2.6.0+bzr6595-6+deb8u1 
1. [CVE-2017-14176](https://security-tracker.debian.org/tracker/CVE-2017-14176 "CVE-2017-14176")   
Severity: Unknown   
Fixed in: 2.6.0+bzr6595-6+deb8u1   

</details>
</p>

<p>
<details>
<summary> Package Name: python2.7 | Current Version: 2.7.9-2+deb8u1   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 2.7.9-2+deb8u5 
1. [CVE-2019-9947](https://security-tracker.debian.org/tracker/CVE-2019-9947 "CVE-2019-9947")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u3   

2. [CVE-2018-20852](https://security-tracker.debian.org/tracker/CVE-2018-20852 "CVE-2018-20852")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u4   

3. [CVE-2018-1060](https://security-tracker.debian.org/tracker/CVE-2018-1060 "CVE-2018-1060")   
Severity: Low   
Fixed in: 2.7.9-2+deb8u2   

4. [CVE-2019-5010](https://security-tracker.debian.org/tracker/CVE-2019-5010 "CVE-2019-5010")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u3   

5. [CVE-2018-1061](https://security-tracker.debian.org/tracker/CVE-2018-1061 "CVE-2018-1061")   
Severity: Low   
Fixed in: 2.7.9-2+deb8u2   

6. [CVE-2018-14647](https://security-tracker.debian.org/tracker/CVE-2018-14647 "CVE-2018-14647")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u3   

7. [CVE-2019-9636](https://security-tracker.debian.org/tracker/CVE-2019-9636 "CVE-2019-9636")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u3   

8. [CVE-2019-9740](https://security-tracker.debian.org/tracker/CVE-2019-9740 "CVE-2019-9740")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u3   

9. [CVE-2018-1000802](https://security-tracker.debian.org/tracker/CVE-2018-1000802 "CVE-2018-1000802")   
Severity: Negligible   
Fixed in: 2.7.9-2+deb8u2   

10. [CVE-2019-16056](https://security-tracker.debian.org/tracker/CVE-2019-16056 "CVE-2019-16056")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u5   

11. [CVE-2019-9948](https://security-tracker.debian.org/tracker/CVE-2019-9948 "CVE-2019-9948")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u3   

12. [CVE-2017-1000158](https://security-tracker.debian.org/tracker/CVE-2017-1000158 "CVE-2017-1000158")   
Severity: Unknown   
Fixed in: 2.7.9-2+deb8u2   

</details>
</p>

<p>
<details>
<summary> Package Name: unzip | Current Version: 6.0-16+deb8u2   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 6.0-21+deb9u1 
1. [CVE-2018-1000035](https://security-tracker.debian.org/tracker/CVE-2018-1000035 "CVE-2018-1000035")   
Severity: Unknown   
Fixed in: 6.0-21+deb9u1   

2. [CVE-2016-9844](https://security-tracker.debian.org/tracker/CVE-2016-9844 "CVE-2016-9844")   
Severity: Unknown   
Fixed in: 6.0-16+deb8u3   

3. [CVE-2014-9913](https://security-tracker.debian.org/tracker/CVE-2014-9913 "CVE-2014-9913")   
Severity: Unknown   
Fixed in: 6.0-16+deb8u3   

</details>
</p>

<p>
<details>
<summary> Package Name: gnupg | Current Version: 1.4.18-7+deb8u3   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 1.4.18-7+deb8u4 
1. [CVE-2017-7526](https://security-tracker.debian.org/tracker/CVE-2017-7526 "CVE-2017-7526")   
Severity: Negligible   
Fixed in: 1.4.18-7+deb8u4   

</details>
</p>

<p>
<details>
<summary> Package Name: bash | Current Version: 4.3-11+deb8u1   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 4.3-11+deb8u2 
1. [CVE-2016-9401](https://security-tracker.debian.org/tracker/CVE-2016-9401 "CVE-2016-9401")   
Severity: Unknown   
Fixed in: 4.3-11+deb8u2   

2. [CVE-2019-9924](https://security-tracker.debian.org/tracker/CVE-2019-9924 "CVE-2019-9924")   
Severity: Low   
Fixed in: 4.3-11+deb8u2   

</details>
</p>

<p>
<details>
<summary> Package Name: curl | Current Version: 7.38.0-4+deb8u5   <strong>(VULNERABLE)</strong>
  </summary> 

##### CVE Vulnerabilities:

*Recommended update* : 7.52.1-5+deb9u10 
1. [CVE-2019-3822](https://security-tracker.debian.org/tracker/CVE-2019-3822 "CVE-2019-3822")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u14   

2. [CVE-2018-1000122](https://security-tracker.debian.org/tracker/CVE-2018-1000122 "CVE-2018-1000122")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u10   

3. [CVE-2018-1000007](https://security-tracker.debian.org/tracker/CVE-2018-1000007 "CVE-2018-1000007")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u9   

4. [CVE-2018-14618](https://security-tracker.debian.org/tracker/CVE-2018-14618 "CVE-2018-14618")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u12   

5. [CVE-2018-1000301](https://security-tracker.debian.org/tracker/CVE-2018-1000301 "CVE-2018-1000301")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u11   

6. [CVE-2017-8817](https://security-tracker.debian.org/tracker/CVE-2017-8817 "CVE-2017-8817")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u8   

7. [CVE-2018-1000120](https://security-tracker.debian.org/tracker/CVE-2018-1000120 "CVE-2018-1000120")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u10   

8. [CVE-2019-5482](https://security-tracker.debian.org/tracker/CVE-2019-5482 "CVE-2019-5482")   
Severity: Unknown   
Fixed in: 7.52.1-5+deb9u10   

9. [CVE-2018-1000121](https://security-tracker.debian.org/tracker/CVE-2018-1000121 "CVE-2018-1000121")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u10   

10. [CVE-2017-1000254](https://security-tracker.debian.org/tracker/CVE-2017-1000254 "CVE-2017-1000254")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u6   

11. [CVE-2017-8816](https://security-tracker.debian.org/tracker/CVE-2017-8816 "CVE-2017-8816")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u8   

12. [CVE-2017-1000100](https://security-tracker.debian.org/tracker/CVE-2017-1000100 "CVE-2017-1000100")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u6   

13. [CVE-2018-16842](https://security-tracker.debian.org/tracker/CVE-2018-16842 "CVE-2018-16842")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u13   

14. [CVE-2019-5436](https://security-tracker.debian.org/tracker/CVE-2019-5436 "CVE-2019-5436")   
Severity: Unknown   
Fixed in: 7.52.1-5+deb9u10   

15. [CVE-2016-9586](https://security-tracker.debian.org/tracker/CVE-2016-9586 "CVE-2016-9586")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u13   

16. [CVE-2019-3823](https://security-tracker.debian.org/tracker/CVE-2019-3823 "CVE-2019-3823")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u14   

17. [CVE-2016-7141](https://security-tracker.debian.org/tracker/CVE-2016-7141 "CVE-2016-7141")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u13   

18. [CVE-2018-16839](https://security-tracker.debian.org/tracker/CVE-2018-16839 "CVE-2018-16839")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u13   

19. [CVE-2018-16890](https://security-tracker.debian.org/tracker/CVE-2018-16890 "CVE-2018-16890")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u14   

20. [CVE-2016-7167](https://security-tracker.debian.org/tracker/CVE-2016-7167 "CVE-2016-7167")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u13   

21. [CVE-2017-1000257](https://security-tracker.debian.org/tracker/CVE-2017-1000257 "CVE-2017-1000257")   
Severity: Unknown   
Fixed in: 7.38.0-4+deb8u7   

</details>
</p>


</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>
Package Name: <strong> org.apache.zookeeper:zookeeper </strong> Version : <strong> 3.4.13 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: CVE-2019-0201
	 Severity:  MODERATE
	 Fixed in Version:  3.4.14
	 Description:  An issue is present in Apache ZooKeeper 1.0.0 to 3.4.13 and 3.5.0-alpha to 3.5.4-beta. ZooKeeper?s getACL() command doesn?t check any permission when retrieves the ACLs of the requested node and returns all information contained in the ACL Id field as plaintext string. DigestAuthenticationProvider overloads the Id field with the hash value that is used for user authentication. As a consequence, if Digest Authentication is in use, the unsalted hash value will be disclosed by getACL() request for unauthenticated or unprivileged users.

	 CVE ID: GHSA-2hw2-62cp-p9p7
	 Severity:  MODERATE
	 Fixed in Version:  3.4.14
	 Description:  An issue is present in Apache ZooKeeper 1.0.0 to 3.4.13 and 3.5.0-alpha to 3.5.4-beta. ZooKeeper?s getACL() command doesn?t check any permission when retrieves the ACLs of the requested node and returns all information contained in the ACL Id field as plaintext string. DigestAuthenticationProvider overloads the Id field with the hash value that is used for user authentication. As a consequence, if Digest Authentication is in use, the unsalted hash value will be disclosed by getACL() request for unauthenticated or unprivileged users.

</details>
</p>

Package Name: <strong> org.apache.tomcat.embed:tomcat-embed-core </strong> Version : <strong> 9.0.17 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: CVE-2019-17563
	 Severity:  HIGH
	 Fixed in Version:  9.0.30
	 Description:  When using FORM authentication with Apache Tomcat 9.0.0.M1 to 9.0.29, 8.5.0 to 8.5.49 and 7.0.0 to 7.0.98 there was a narrow window where an attacker could perform a session fixation attack. The window was considered too narrow for an exploit to be practical but, erring on the side of caution, this issue has been treated as a security vulnerability.

	 CVE ID: GHSA-9xcj-c8cr-8c3c
	 Severity:  HIGH
	 Fixed in Version:  9.0.30
	 Description:  When using FORM authentication with Apache Tomcat 9.0.0.M1 to 9.0.29, 8.5.0 to 8.5.49 and 7.0.0 to 7.0.98 there was a narrow window where an attacker could perform a session fixation attack. The window was considered too narrow for an exploit to be practical but, erring on the side of caution, this issue has been treated as a security vulnerability.

	 CVE ID: CVE-2019-12418
	 Severity:  MODERATE
	 Fixed in Version:  9.0.29
	 Description:  When Apache Tomcat 9.0.0.M1 to 9.0.28, 8.5.0 to 8.5.47, 7.0.0 and 7.0.97 is configured with the JMX Remote Lifecycle Listener, a local attacker without access to the Tomcat process or configuration files is able to manipulate the RMI registry to perform a man-in-the-middle attack to capture user names and passwords used to access the JMX interface. The attacker can then use these credentials to access the JMX interface and gain complete control over the Tomcat instance.

	 CVE ID: GHSA-hh3j-x4mc-g48r
	 Severity:  MODERATE
	 Fixed in Version:  9.0.29
	 Description:  When Apache Tomcat 9.0.0.M1 to 9.0.28, 8.5.0 to 8.5.47, 7.0.0 and 7.0.97 is configured with the JMX Remote Lifecycle Listener, a local attacker without access to the Tomcat process or configuration files is able to manipulate the RMI registry to perform a man-in-the-middle attack to capture user names and passwords used to access the JMX interface. The attacker can then use these credentials to access the JMX interface and gain complete control over the Tomcat instance.

	 CVE ID: CVE-2020-1935
	 Severity:  MODERATE
	 Fixed in Version:  9.0.31
	 Description:  In Apache Tomcat 9.0.0.M1 to 9.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99 the HTTP header parsing code used an approach to end-of-line parsing that allowed some invalid HTTP headers to be parsed as valid. This led to a possibility of HTTP Request Smuggling if Tomcat was located behind a reverse proxy that incorrectly handled the invalid Transfer-Encoding header in a particular manner. Such a reverse proxy is considered unlikely.

	 CVE ID: GHSA-qxf4-chvg-4r8r
	 Severity:  MODERATE
	 Fixed in Version:  9.0.31
	 Description:  In Apache Tomcat 9.0.0.M1 to 9.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99 the HTTP header parsing code used an approach to end-of-line parsing that allowed some invalid HTTP headers to be parsed as valid. This led to a possibility of HTTP Request Smuggling if Tomcat was located behind a reverse proxy that incorrectly handled the invalid Transfer-Encoding header in a particular manner. Such a reverse proxy is considered unlikely.

</details>
</p>


</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/refarch-kc-ui/Dockerfile
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/refarch-kc-ui/Dockerfile
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:x: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>
Package Name: <strong> minimist </strong> Version : <strong> 0.0.8 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: GHSA-7fhm-mqm4-2wp7
	 Severity:  MODERATE
	 Fixed in Version:  0.2.1
	 Description:  **Withdrawn**
GitHub has withdrawn this advisory in place of GHSA-vh95-rmgr-6w4m and GHSA-6chw-6frg-f759.
The reason for withdrawing is that some mistakes were made during the ingestion of CVE-2020-7598
which caused this advisory to be published with incorrect information.

In order to provide accurate advisory information, new advisories were created:

- minimist: https://github.com/advisories/GHSA-vh95-rmgr-6w4m
- acorn: https://github.com/advisories/GHSA-6chw-6frg-f759

</details>
</p>

Package Name: <strong> acorn </strong> Version : <strong> 6.4.0 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: GHSA-6chw-6frg-f759
	 Severity:  MODERATE
	 Fixed in Version:  6.4.1
	 Description:  Affected versions of acorn are vulnerable to Regular Expression Denial of Service.
A regex in the form of /[x-?]/u causes the parser to enter an infinite loop.
The string is not valid UTF16 which usually results in it being sanitized before reaching the parser.
If an application processes untrusted input and passes it directly to acorn,
attackers may leverage the vulnerability leading to Denial of Service.

</details>
</p>

Package Name: <strong> kind-of </strong> Version : <strong> 6.0.2 </strong>
<p>
<details>
<summary> CVEs  </summary> 

	 CVE ID: CVE-2019-20149
	 Severity:  MODERATE
	 Fixed in Version:  6.0.3
	 Description:  ctorName in index.js in kind-of v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by 'constructor': {'name':'Symbol'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.

	 CVE ID: GHSA-6c8f-qphg-qjgp
	 Severity:  MODERATE
	 Fixed in Version:  6.0.3
	 Description:  ctorName in index.js in kind-of v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by 'constructor': {'name':'Symbol'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.

</details>
</p>


</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/order-query-quarkus-ms/src/main/docker/Dockerfile.jvm
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/order-command-quarkus-ms/src/main/docker/Dockerfile.jvm-back
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/order-command-quarkus-ms/src/main/docker/Dockerfile.jvm-back
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/order-command-quarkus-ms/src/main/docker/Dockerfile.jvm
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>/kcontainer/fleet-quarkus-ms/src/main/docker/Dockerfile.jvm
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
:white_check_mark: Java Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Java Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

